### PR TITLE
fix: Replace expired service token with built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set up Go 1.24
         uses: actions/setup-go@v7
@@ -25,4 +27,5 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.TIS_SERVICE_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TIS_SERVICE_USER_TOKEN: ${{ secrets.TIS_SERVICE_USER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,3 +54,4 @@ homebrew_casks:
       owner: dueckminor
       name: go-sshtunnel
       branch: main
+      token: "{{ .Env.TIS_SERVICE_USER_TOKEN }}"


### PR DESCRIPTION
The release was failing with 401 Bad credentials because `TIS_SERVICE_USER_TOKEN` was used for both the GitHub release API call and the homebrew cask commit. This replaces the release authentication with the built-in `GITHUB_TOKEN` (which requires permissions: contents: write to create releases) and wires `TIS_SERVICE_USER_TOKEN` explicitly into the goreleaser homebrew cask config via token: `{{ .Env.TIS_SERVICE_USER_TOKEN }}` — the pattern goreleaser actually supports for per-integration token overrides.